### PR TITLE
fix name for xor tests

### DIFF
--- a/code/python-oop-tdd-part1/test_binary_ver2.py
+++ b/code/python-oop-tdd-part1/test_binary_ver2.py
@@ -147,7 +147,7 @@ def test_binary_or():
     assert Binary('1101') | Binary('1') == Binary('1101')
 
 
-def test_binary_or():
+def test_binary_xor():
     assert Binary('1101') ^ Binary('1') == Binary('1100')
 
 

--- a/code/python-oop-tdd-part1/test_binary_ver3.py
+++ b/code/python-oop-tdd-part1/test_binary_ver3.py
@@ -147,7 +147,7 @@ def test_binary_or():
     assert Binary('1101') | Binary('1') == Binary('1101')
 
 
-def test_binary_or():
+def test_binary_xor():
     assert Binary('1101') ^ Binary('1') == Binary('1100')
 
 

--- a/code/python-oop-tdd-part1/test_binary_ver4.py
+++ b/code/python-oop-tdd-part1/test_binary_ver4.py
@@ -147,7 +147,7 @@ def test_binary_or():
     assert Binary('1101') | Binary('1') == Binary('1101')
 
 
-def test_binary_or():
+def test_binary_xor():
     assert Binary('1101') ^ Binary('1') == Binary('1100')
 
 


### PR DESCRIPTION
I spotted typo in our test function name. There was two test with the name test_binary_or.